### PR TITLE
feat: experiemental impl of layer shell window using pop variant of iced (WIP)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: sudo apt-get install libxkbcommon-dev libwayland-dev
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Configure cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: sudo apt-get install libxkbcommon-dev libwayland-dev
       - name: Setup Rust (nightly)
         uses: dtolnay/rust-toolchain@nightly
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: sudo apt-get install libxkbcommon-dev libwayland-dev
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Configure cache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elbey"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-dirs = "5.0"
+dirs = "6.0"
 freedesktop-desktop-entry = "0.7"
 iced = { git = "https://github.com/pop-os/iced", features = [ "wayland", "winit", "wgpu" ] } # { version = "0.13", features = ["wgpu"] }
 shell-words = "^1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 anyhow = "1.0"
 dirs = "5.0"
 freedesktop-desktop-entry = "0.7"
-iced = { version = "0.13", features = ["wgpu"] }
-iced_core = "0.13"
-iced_runtime = "0.13"
+iced = { git = "https://github.com/pop-os/iced", features = [ "wayland", "winit", "wgpu" ] } # { version = "0.13", features = ["wgpu"] }
 shell-words = "^1"
+cctk = { git = "https://github.com/pop-os/cosmic-protocols", package = "cosmic-client-toolkit", rev = "d218c76" }

--- a/README.md
+++ b/README.md
@@ -54,6 +54,6 @@ which elbey # where cargo installed the binary
 
 ## Credit
 
-This program was inspired by the friendly docs of [`iced`](https://github.com/iced-rs/iced) itself, other desktop app launchers such as [pop-launcher](https://github.com/pop-os/launcher) and [onagre](https://github.com/onagre-launcher/onagre), and the greater Rust desktop cohort.  Of course the venerable [`rofi`](https://github.com/davatorium/rofi) must also be mentioned.
+This program was inspired by the friendly docs of [`iced`](https://github.com/iced-rs/iced) itself, other desktop app launchers such as [pop-launcher](https://github.com/pop-os/launcher) and [onagre](https://github.com/onagre-launcher/onagre), [`iced_launcher`](https://github.com/Decodetalkers/iced_launcher), and the greater Rust desktop cohort.  Of course the venerable [`rofi`](https://github.com/davatorium/rofi) must also be mentioned.
 
 Project logo was created by Mira Gilmer.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,6 @@ which elbey # where cargo installed the binary
 
 ## Credit
 
-This program was inspired by the friendly docs of [`iced`](https://github.com/iced-rs/iced) itself, other desktop app launchers such as [pop-launcher](https://github.com/pop-os/launcher) and [onagre](https://github.com/onagre-launcher/onagre), [`iced_launcher`](https://github.com/Decodetalkers/iced_launcher), and the greater Rust desktop cohort.  Of course the venerable [`rofi`](https://github.com/davatorium/rofi) must also be mentioned.
+This program was inspired by the friendly docs of [`iced`](https://github.com/iced-rs/iced) itself, other desktop app launchers such as [pop-launcher](https://github.com/pop-os/launcher) and [onagre](https://github.com/onagre-launcher/onagre), [`gauntlet`](https://github.com/project-gauntlet/gauntlet/), [`iced_launcher`](https://github.com/Decodetalkers/iced_launcher), and the greater Rust desktop cohort.  Of course the venerable [`rofi`](https://github.com/davatorium/rofi) must also be mentioned.
 
 Project logo was created by Mira Gilmer.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ The application is functional in that desktop apps can be launched from the dial
 Things that might be fun to add to `ebley`:
 
 * Sort the entries by usage or name
-* Implement page up and page down
+* ~Use layer shell so window always on top of existing windows~ (Done: [Pull Request](https://github.com/kgilmer/elbey/pull/5))
+* ~Implement page up and page down~ (Done: [Pull Request](https://github.com/kgilmer/elbey/pull/5))
 * Add caching to speed up retrieval of the apps
 * Show app icons in addition to the titles
 * Allow theme to be selected from the command line

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,16 +3,14 @@ use std::process::exit;
 use std::sync::LazyLock;
 
 use freedesktop_desktop_entry::DesktopEntry;
+use iced::keyboard::key::Named;
+use iced::keyboard::Key;
+use iced::platform_specific::shell::commands::layer_surface::get_layer_surface;
+use iced::platform_specific::shell::commands::overlap_notify::overlap_notify;
 use iced::widget::button::{primary, text};
 use iced::widget::scrollable::{snap_to, RelativeOffset};
 use iced::widget::{button, column, scrollable, text_input, Column};
 use iced::{event, window, Element, Event, Length, Task};
-use iced::keyboard::key::Named;
-use iced::keyboard::Key;
-use iced::platform_specific::shell::commands::layer_surface::get_layer_surface;
-use iced::platform_specific::shell::commands::{
-    overlap_notify::overlap_notify,
-};
 
 /// A magic value to calculate relative pixel hight to move one item in the scrollable
 const ITEM_HEIGHT_SCALE_FACTOR: f32 = 0.00750;
@@ -82,13 +80,16 @@ impl Elbey {
         let load_task = Task::perform(async {}, move |_| {
             ElbeyMessage::ModelLoaded((flags.apps_loader)())
         });
-        let layer_shell_task = get_layer_surface(iced::platform_specific::runtime::wayland::layer_surface::SctkLayerSurfaceSettings {
-            id,
-            size: Some((Some(320), Some(200))),
-            pointer_interactivity: true,
-            keyboard_interactivity: cctk::sctk::shell::wlr_layer::KeyboardInteractivity::OnDemand,
-            ..Default::default()
-        });
+        let layer_shell_task = get_layer_surface(
+            iced::platform_specific::runtime::wayland::layer_surface::SctkLayerSurfaceSettings {
+                id,
+                size: Some((Some(320), Some(200))),
+                pointer_interactivity: true,
+                keyboard_interactivity:
+                    cctk::sctk::shell::wlr_layer::KeyboardInteractivity::OnDemand,
+                ..Default::default()
+            },
+        );
 
         (
             Self {
@@ -209,10 +210,10 @@ impl Elbey {
             }) => Some(ElbeyMessage::KeyEvent(key)),
             Event::PlatformSpecific(event::PlatformSpecific::Wayland(
                 event::wayland::Event::Layer(e, ..),
-            ))=> {
+            )) => {
                 dbg!(e);
                 None
-            },
+            }
             _ => None,
         })
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,8 @@ use std::sync::LazyLock;
 use anyhow::Context;
 use app::{Elbey, ElbeyFlags};
 use freedesktop_desktop_entry::{default_paths, get_languages_from_env, DesktopEntry, Iter};
-use iced::{Font, Pixels};
 use iced::Theme;
+use iced::{Font, Pixels};
 
 static PROGRAM_NAME: LazyLock<String> = std::sync::LazyLock::new(|| String::from("Elbey"));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,43 +8,21 @@ use std::sync::LazyLock;
 use anyhow::Context;
 use app::{Elbey, ElbeyFlags};
 use freedesktop_desktop_entry::{default_paths, get_languages_from_env, DesktopEntry, Iter};
-use iced::window;
-use iced::{window::settings::PlatformSpecific, Theme};
-use iced_core::{Font, Pixels, Size};
+use iced::{Font, Pixels};
+use iced::Theme;
 
 static PROGRAM_NAME: LazyLock<String> = std::sync::LazyLock::new(|| String::from("Elbey"));
 
 /// Program entrypoint.  Just configures the app, window, and kicks off the iced runtime.
 fn main() -> iced::Result {
-    // UI settings
     let iced_settings = iced::settings::Settings {
         id: Some(PROGRAM_NAME.to_string()),
         fonts: vec![],
         default_font: Font::DEFAULT,
         default_text_size: Pixels::from(18),
         antialiasing: true,
-    };
-
-    // Window settings
-    let window_settings = window::Settings {
-        size: Size {
-            width: 320.0,
-            height: 200.0,
-        },
-        position: window::Position::Centered,
-        min_size: None,
-        max_size: None,
-        visible: true,
-        resizable: false,
-        decorations: false,
-        transparent: false,
-        level: Default::default(),
-        icon: None,
-        platform_specific: PlatformSpecific {
-            application_id: PROGRAM_NAME.to_string(),
-            override_redirect: false,
-        },
         exit_on_close_request: true,
+        is_daemon: false,
     };
 
     // A function that returns the app struct
@@ -55,11 +33,9 @@ fn main() -> iced::Result {
         })
     };
 
-    // Kick off iced GUI
-    iced::application(PROGRAM_NAME.as_str(), Elbey::update, Elbey::view)
+    iced::daemon(PROGRAM_NAME.as_str(), Elbey::update, Elbey::view)
         .settings(iced_settings)
-        .window(window_settings)
-        .theme(|_| Theme::Nord)
+        .theme(|_, _| Theme::Nord)
         .subscription(Elbey::subscription)
         .run_with(app_factory)
 }


### PR DESCRIPTION
Before change (standard impl) these windows are visible to Sway:

```
$ swaymsg -t get_tree
...
    #17: workspace "3"
      #66: con "main.rs - iced-pop - VSCodium" (xwayland, pid: 28436, instance: "vscodium", class: "VSCodium", X11 window: 0x120003E)
      #49: con "app.rs - elbey - VSCodium" (xwayland, pid: 28436, instance: "vscodium", class: "VSCodium", X11 window: 0x120003C)
      #72: floating_con "Elbey" (xdg_shell, pid: 298317, app_id: "Elbey")
```

After change, the launcher is not visible to Sway, indicating a layer shell window:

```
$ swaymsg -t get_tree
...
#17: workspace "3"
      #66: con "main.rs - iced-pop - VSCodium" (xwayland, pid: 28436, instance: "vscodium", class: "VSCodium", X11 window: 0x120003E)
      #49: con "app.rs - elbey - VSCodium" (xwayland, pid: 28436, instance: "vscodium", class: "VSCodium", X11 window: 0x120003C)
```